### PR TITLE
Annotate RPC methods with idempotency levels

### DIFF
--- a/proto/cusf/mainchain/v1/validator.proto
+++ b/proto/cusf/mainchain/v1/validator.proto
@@ -74,31 +74,57 @@ message BlockInfo {
 service ValidatorService {
   // Fetches information about a specific mainchain block header,
   // and optionally, it's ancestors
-  rpc GetBlockHeaderInfo(GetBlockHeaderInfoRequest) returns (GetBlockHeaderInfoResponse);
+  rpc GetBlockHeaderInfo(GetBlockHeaderInfoRequest) returns (GetBlockHeaderInfoResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 
   // Fetches information about a specific mainchain block (and optionally,
   // it's ancestors), regarding how it pertains to events happening on a
   // specific sidechain.
-  rpc GetBlockInfo(GetBlockInfoRequest) returns (GetBlockInfoResponse);
+  rpc GetBlockInfo(GetBlockInfoRequest) returns (GetBlockInfoResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   // Fetches BMM h* commitment for a specific mainchain block,
   // and optionally, it's ancestors
-  rpc GetBmmHStarCommitment(GetBmmHStarCommitmentRequest) returns (GetBmmHStarCommitmentResponse);
-  rpc GetChainInfo(GetChainInfoRequest) returns (GetChainInfoResponse);
-  rpc GetChainTip(GetChainTipRequest) returns (GetChainTipResponse);
-  rpc GetCoinbasePSBT(GetCoinbasePSBTRequest) returns (GetCoinbasePSBTResponse);
-  rpc GetCtip(GetCtipRequest) returns (GetCtipResponse);
-  rpc GetSidechainProposals(GetSidechainProposalsRequest) returns (GetSidechainProposalsResponse);
-  rpc GetSidechains(GetSidechainsRequest) returns (GetSidechainsResponse);
-  rpc GetTwoWayPegData(GetTwoWayPegDataRequest) returns (GetTwoWayPegDataResponse);
-  rpc SubscribeEvents(SubscribeEventsRequest) returns (stream SubscribeEventsResponse);
+  rpc GetBmmHStarCommitment(GetBmmHStarCommitmentRequest) returns (GetBmmHStarCommitmentResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetChainInfo(GetChainInfoRequest) returns (GetChainInfoResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetChainTip(GetChainTipRequest) returns (GetChainTipResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetCoinbasePSBT(GetCoinbasePSBTRequest) returns (GetCoinbasePSBTResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetCtip(GetCtipRequest) returns (GetCtipResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetSidechainProposals(GetSidechainProposalsRequest) returns (GetSidechainProposalsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetSidechains(GetSidechainsRequest) returns (GetSidechainsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetTwoWayPegData(GetTwoWayPegDataRequest) returns (GetTwoWayPegDataResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc SubscribeEvents(SubscribeEventsRequest) returns (stream SubscribeEventsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 
   // Stream header sync progress updates
-  rpc SubscribeHeaderSyncProgress(SubscribeHeaderSyncProgressRequest) returns (stream SubscribeHeaderSyncProgressResponse);
+  rpc SubscribeHeaderSyncProgress(SubscribeHeaderSyncProgressRequest) returns (stream SubscribeHeaderSyncProgressResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 
   // Safely shutdown the validator. This is equivalent to sending a SIGINT
   // to the validator process, and can be used to trigger a graceful shutdown
   // in cases where you don't have access to the validator process.
-  rpc Stop(StopRequest) returns (StopResponse);
+  rpc Stop(StopRequest) returns (StopResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
 }
 
 message GetBlockHeaderInfoRequest {

--- a/proto/cusf/mainchain/v1/wallet.proto
+++ b/proto/cusf/mainchain/v1/wallet.proto
@@ -26,7 +26,9 @@ message WalletTransaction {
 }
 
 service WalletService {
-  rpc BroadcastWithdrawalBundle(BroadcastWithdrawalBundleRequest) returns (BroadcastWithdrawalBundleResponse);
+  rpc BroadcastWithdrawalBundle(BroadcastWithdrawalBundleRequest) returns (BroadcastWithdrawalBundleResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
   rpc CreateBmmCriticalDataTransaction(CreateBmmCriticalDataTransactionRequest) returns (CreateBmmCriticalDataTransactionResponse);
   rpc CreateDepositTransaction(CreateDepositTransactionRequest) returns (CreateDepositTransactionResponse);
   rpc CreateNewAddress(CreateNewAddressRequest) returns (CreateNewAddressResponse);
@@ -38,13 +40,25 @@ service WalletService {
   // Returns a stream of (non-)confirmation events for the sidechain proposal.
   rpc CreateSidechainProposal(CreateSidechainProposalRequest) returns (stream CreateSidechainProposalResponse);
   rpc CreateWallet(CreateWalletRequest) returns (CreateWalletResponse);
-  rpc GetBalance(GetBalanceRequest) returns (GetBalanceResponse);
-  rpc ListSidechainDepositTransactions(ListSidechainDepositTransactionsRequest) returns (ListSidechainDepositTransactionsResponse);
-  rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse);
-  rpc ListUnspentOutputs(ListUnspentOutputsRequest) returns (ListUnspentOutputsResponse);
-  rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
+  rpc GetBalance(GetBalanceRequest) returns (GetBalanceResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc ListSidechainDepositTransactions(ListSidechainDepositTransactionsRequest) returns (ListSidechainDepositTransactionsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc ListUnspentOutputs(ListUnspentOutputsRequest) returns (ListUnspentOutputsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   rpc SendTransaction(SendTransactionRequest) returns (SendTransactionResponse);
-  rpc UnlockWallet(UnlockWalletRequest) returns (UnlockWalletResponse);
+  rpc UnlockWallet(UnlockWalletRequest) returns (UnlockWalletResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
   // Available on regtest and signet only.
   rpc GenerateBlocks(GenerateBlocksRequest) returns (stream GenerateBlocksResponse);
 }

--- a/proto/cusf/sidechain/v1/sidechain.proto
+++ b/proto/cusf/sidechain/v1/sidechain.proto
@@ -17,10 +17,18 @@ message BlockHeaderInfo {
 message BlockInfo {}
 
 service SidechainService {
-  rpc GetMempoolTxs(GetMempoolTxsRequest) returns (GetMempoolTxsResponse);
-  rpc GetUtxos(GetUtxosRequest) returns (GetUtxosResponse);
-  rpc SubmitTransaction(SubmitTransactionRequest) returns (SubmitTransactionResponse);
-  rpc SubscribeEvents(SubscribeEventsRequest) returns (stream SubscribeEventsResponse);
+  rpc GetMempoolTxs(GetMempoolTxsRequest) returns (GetMempoolTxsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetUtxos(GetUtxosRequest) returns (GetUtxosResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc SubmitTransaction(SubmitTransactionRequest) returns (SubmitTransactionResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  rpc SubscribeEvents(SubscribeEventsRequest) returns (stream SubscribeEventsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 message GetMempoolTxsRequest {}


### PR DESCRIPTION
This is to make it possible to call the endpoints using `GET` in addition to `POST`.