### PR TITLE
validator: add GetCtips

### DIFF
--- a/proto/cusf/mainchain/v1/validator.proto
+++ b/proto/cusf/mainchain/v1/validator.proto
@@ -101,6 +101,11 @@ service ValidatorService {
   rpc GetCtip(GetCtipRequest) returns (GetCtipResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // Fetches the Ctip for every active sidechain that has one, in a single
+  // request. Avoids calling GetCtip once per sidechain.
+  rpc GetCtips(GetCtipsRequest) returns (GetCtipsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   rpc GetSidechainProposals(GetSidechainProposalsRequest) returns (GetSidechainProposalsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
@@ -272,6 +277,19 @@ message GetCtipResponse {
     uint64 sequence_number = 4;
   }
   optional Ctip ctip = 1;
+}
+
+message GetCtipsRequest {}
+message GetCtipsResponse {
+  message Ctip {
+    google.protobuf.UInt32Value sidechain_number = 1;
+    cusf.common.v1.ReverseHex txid = 2;
+    uint32 vout = 3;
+    uint64 value = 4;
+    uint64 sequence_number = 5;
+  }
+  // One entry per active sidechain that has a Ctip.
+  repeated Ctip ctips = 1;
 }
 
 message GetSidechainProposalsRequest {}


### PR DESCRIPTION
adds `GetCtips`, which returns the ctip for every active sidechain in one request instead of calling `GetCtip` once per sidechain.

bitwindow already does that per-sidechain loop and had to add a cache around it to avoid the repeated calls (the comment literally says "avoid repeated enforcer calls for GetCtip on every sidechain"): [bitwindow/server/api/drivechain/drivechain.go#L153-L211](https://github.com/LayerTwo-Labs/drivechain-frontends/blob/51f4185fc00b73a82fe20c5171adcb7dcf3e1a78/bitwindow/server/api/drivechain/drivechain.go#L153-L211)

GetCtips collapses that to a single call. it follows the same batching direction as the earlier batch-header and batch-block-info changes.

enforcers  haveexisting `validator::get_ctips()`, so theres no new logic on the node side. additive only, buf breaking passes against master. enforcer implementation will follow in a separate pr once this is merged.